### PR TITLE
Fix doctrine prepare statement.

### DIFF
--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -960,6 +960,7 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
             'AND `tx_dlf_documents`.`pid` = ? ' .
             'AND `tx_dlf_collections`.`pid` = ? ' .
             'AND `tx_dlf_relations`.`ident`="docs_colls" ' .
+            'AND ' . Helper::whereExpression('tx_dlf_collections') . ' ' .
             'GROUP BY `tx_dlf_documents`.`uid` ' .
             'LIMIT ?';
 


### PR DESCRIPTION
    The current solution only works for the first uid in the list of
    $documentsToProcess. This is due to a wrong usage of the doctrine
    prepare statement.

    Additionally the GROUP BY is required in the SQL query. Otherwise only
    one result is get.

There is another query with prepare() in this plugin which should be checked. This may work as there is no `IN()` operator in use.